### PR TITLE
Prevent Converter Causing Exceptions

### DIFF
--- a/src/JsonKnownTypes/JsonKnownTypesConverter.cs
+++ b/src/JsonKnownTypes/JsonKnownTypesConverter.cs
@@ -26,6 +26,8 @@ namespace JsonKnownTypes
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            if (reader.TokenType == JsonToken.Null) return null;
+            
             var jo = JObject.Load(reader);
 
             var discriminator = jo[_typesDiscriminatorValues.FieldName].ToString();


### PR DESCRIPTION
Presence of JsonKnownTypes was causing exceptions during normal operation of RethinkDB driver. I tracked down the exception to a lack of null handling in JsonKnownTypesConverter, fixed the problem.