### PR TITLE
Change target framework to multiple frameworks, add net461

### DIFF
--- a/src/JsonKnownTypes/JsonKnownTypes.csproj
+++ b/src/JsonKnownTypes/JsonKnownTypes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/JsonKnownTypes/JsonKnownTypes.csproj
+++ b/src/JsonKnownTypes/JsonKnownTypes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net45;net40;net35;net20;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/JsonKnownTypes.Benchmark/JsonKnownTypes.Benchmark.csproj
+++ b/tests/JsonKnownTypes.Benchmark/JsonKnownTypes.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/JsonKnownTypes.Benchmark/JsonKnownTypes.Benchmark.csproj
+++ b/tests/JsonKnownTypes.Benchmark/JsonKnownTypes.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net46;net40;net35;net20;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/JsonKnownTypes.UnitTests/JsonKnownTypes.UnitTests.csproj
+++ b/tests/JsonKnownTypes.UnitTests/JsonKnownTypes.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/JsonKnownTypes.UnitTests/JsonKnownTypes.UnitTests.csproj
+++ b/tests/JsonKnownTypes.UnitTests/JsonKnownTypes.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net46;net40;net35;net20;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I followed this article: https://weblog.west-wind.com/posts/2017/Jun/22/MultiTargeting-and-Porting-a-NET-Library-to-NET-Core-20
It contains some useful tips if you need to differentiate code depending on which framework it is built for. This was not needed in this project however.

I have never released a NuGet package so I don't know this process. This creates separate folders, for each framework, in the package file.