### PR TITLE
Custom Name resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,13 @@ Json representation:
 { ... , "$type":"just_joke=)" }
 ```
 ### Configuration
-To change default discriminator settings use:
+To change global default discriminator settings use:
 ```c#
 JsonKnownTypesSettingsManager.DefaultDiscriminatorSettings = new JsonDiscriminatorSettings
 {
     DiscriminatorFieldName = "name",
-    UseClassNameAsDiscriminator = false
+    UseClassNameAsDiscriminator = false,
+    NameDiscriminatorResolver = type => type.FullName
 };
 ```
 > `DiscriminatorFieldName` change default `"$type"` name to yours  
@@ -141,6 +142,19 @@ var entityJson = JsonConvert.SerializeObject(entity, converter);
 var obj = DeserializeObject<BaseClass>(entityJson, converter)
 ```
 > You have to pass a converter directly to method if you do not use `JsonConverter` attribute.
+
+
+To change type specific discriminator settings use:
+```c#
+JsonKnownTypesSettingsManager<BaseClass>.DefaultDiscriminatorSettings = new JsonDiscriminatorSettings
+{
+    DiscriminatorFieldName = "name",
+    UseClassNameAsDiscriminator = false,
+    NameDiscriminatorResolver = type => type.FullName
+};
+```
+Type specific configuration overrules the global default settings, and can be used to inject type specific configuration without using attributes
+
 ### Fallback type deserialization
 Normally you will receive an exception during deserialization of models marked with unknown or
 unspecified type discriminator. If you need an exception-free way you can use `JsonKnownTypeFallback` attribute.

--- a/src/JsonKnownTypes/DiscriminatorValuesManager.cs
+++ b/src/JsonKnownTypes/DiscriminatorValuesManager.cs
@@ -33,14 +33,14 @@ namespace JsonKnownTypes
             }
         }
 
-        internal static void AddAutoDiscriminators(this DiscriminatorValues discriminatorValues, Type[] inherited)
+        internal static void AddAutoDiscriminators(this DiscriminatorValues discriminatorValues, Type[] inherited, Func<Type, string> nameResolver)
         {
             foreach (var type in inherited)
             {
                 if (discriminatorValues.Contains(type))
                     continue;
-
-                discriminatorValues.AddType(type, type.Name);
+                
+                discriminatorValues.AddType(type, nameResolver(type));
             }
         }
     }

--- a/src/JsonKnownTypes/JsonDiscriminatorSettings.cs
+++ b/src/JsonKnownTypes/JsonDiscriminatorSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace JsonKnownTypes
+﻿using System;
+
+namespace JsonKnownTypes
 {
     public class JsonDiscriminatorSettings
     {
@@ -11,5 +13,10 @@
         /// Use class name as discriminator if JsonKnown attribute hasn't been added
         /// </summary>
         public bool UseClassNameAsDiscriminator { get; set; } = true;
+
+        /// <summary>
+        /// Use a type property as name resolver. Default: type.Name
+        /// </summary>
+        public Func<Type, string> NameDiscriminatorResolver { get; set; } = type => type.Name;
     }
 }

--- a/src/JsonKnownTypes/JsonKnownTypesSettingsManager.cs
+++ b/src/JsonKnownTypes/JsonKnownTypesSettingsManager.cs
@@ -1,17 +1,24 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using JsonKnownTypes.Utils;
 
 namespace JsonKnownTypes
 {
+    public static class JsonKnownTypesSettingsManager<T>
+    {
+        /// <summary>
+        /// Type specific default settings for discriminator
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType - Justification: Intentional property should exist on a per-type base
+        public static JsonDiscriminatorSettings DefaultDiscriminatorSettings { get; } = new();
+    }
+
     public static class JsonKnownTypesSettingsManager
     {
         /// <summary>
-        /// Default settings for discriminator
+        /// Global Default settings for discriminator
         /// </summary>
-        public static JsonDiscriminatorSettings DefaultDiscriminatorSettings { get; set; } =
-            new JsonDiscriminatorSettings();
+        public static JsonDiscriminatorSettings DefaultDiscriminatorSettings { get; set; } = new();
 
         /// <summary>
         /// Function for search derived classes (By default in base class assembly only)
@@ -23,8 +30,9 @@ namespace JsonKnownTypes
         {
             var discriminatorAttribute = AttributesManager.GetJsonDiscriminatorAttribute(typeof(T));
 
-            var discriminatorSettings = discriminatorAttribute == null 
-                ? DefaultDiscriminatorSettings 
+            var discriminatorSettings = discriminatorAttribute == null
+                ? JsonKnownTypesSettingsManager<T>.DefaultDiscriminatorSettings
+                  ??  DefaultDiscriminatorSettings
                 : Mapper.Map(discriminatorAttribute);
 
             var typeSettings = new DiscriminatorValues(typeof(T), discriminatorSettings.DiscriminatorFieldName);
@@ -36,7 +44,7 @@ namespace JsonKnownTypes
 
             if (discriminatorSettings.UseClassNameAsDiscriminator)
             {
-                typeSettings.AddAutoDiscriminators(allTypes);
+                typeSettings.AddAutoDiscriminators(allTypes, discriminatorSettings.NameDiscriminatorResolver);
             }
 
             return typeSettings;

--- a/tests/JsonKnownTypes.UnitTests/WithNameDiscriminatorResolverTests.cs
+++ b/tests/JsonKnownTypes.UnitTests/WithNameDiscriminatorResolverTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonKnownTypes.UnitTests
+{
+    public class WithNameDiscriminatorResolverTests
+    {
+        [Test]
+        public void BaseClassTest()
+        {
+            var entity = new a.ClassInContainer();
+            JsonKnownTypesSettingsManager<ClassWithDuplicateChild>.DefaultDiscriminatorSettings.NameDiscriminatorResolver = type => type.FullName;
+            var json = JsonConvert.SerializeObject(entity);
+
+            json.Should().Be("{\"$type\":\"JsonKnownTypes.UnitTests.a.ClassInContainer\"}");
+
+            var obj = JsonConvert.DeserializeObject<ClassWithDuplicateChild>(json);
+            obj.GetType().Should().Be(entity.GetType());
+        }
+    }
+
+    [JsonConverter(typeof(JsonKnownTypesConverter<ClassWithDuplicateChild>))]
+    public class ClassWithDuplicateChild
+    {
+    }
+}
+
+namespace JsonKnownTypes.UnitTests.a
+{
+
+    public class ClassInContainer : ClassWithDuplicateChild
+    {
+    }
+}
+
+namespace JsonKnownTypes.UnitTests.b
+{
+    // ReSharper disable once UnusedType.Global - Justification: Used by deserializer as duplicate class example
+    public class ClassInContainer : ClassWithDuplicateChild
+    {
+    }
+}


### PR DESCRIPTION
 - Added `public Func<Type, string> NameDiscriminatorResolver { get; set; } = type => type.Name;` to JsonDiscriminatorSettings to allow custom Name Discriminator Resolver
 - Added JsonKnownTypesSettingsManager<T> To allow type specific config to be injected